### PR TITLE
Fix type errors

### DIFF
--- a/src/vteconv.cc
+++ b/src/vteconv.cc
@@ -771,7 +771,7 @@ int
 main (int argc,
       char *argv[])
 {
-        g_test_init (&argc, &argv, NULL);
+        g_test_init (&argc, &argv, (char *)NULL);
 
         g_test_add_func ("/vte/conv/utf8/strlen", test_utf8_strlen);
         g_test_add_func ("/vte/conv/utf8/validate", test_utf8_validate);

--- a/src/vteseq.cc
+++ b/src/vteseq.cc
@@ -3409,7 +3409,7 @@ vte_sequence_handler_iterm2_1337(VteTerminalPrivate *that, GValueArray *params)
 #define VTE_SEQUENCE_HANDLER(name) name
 
 static const struct vteseq_n_struct *
-vteseq_n_lookup (register const char *str, register unsigned int len);
+vteseq_n_lookup (register const char *str, register size_t len);
 #include"vteseq-n.cc"
 
 #undef VTE_SEQUENCE_HANDLER

--- a/src/vtetypes.cc
+++ b/src/vtetypes.cc
@@ -407,7 +407,7 @@ test_util_smart_fd(void)
 int
 main(int argc, char *argv[])
 {
-        g_test_init (&argc, &argv, NULL);
+        g_test_init (&argc, &argv, (char *)NULL);
 
         g_test_add_func("/vte/c++/grid/coords", test_grid_coords);
         g_test_add_func("/vte/c++/grid/span", test_grid_span);


### PR DESCRIPTION
I fixed some type errors, which surfaced when trying to compile vte-ng with
gcc 5.4 during packaging for the Nix package manager.