### PR TITLE
Add AC_CONFIG_AUX_DIR to make sure ltmain.sh is copied to the right directory

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AC_INIT([vte],
         [version_triplet],
         [http://bugzilla.gnome.org/enter_bug.cgi?product=vte],
         [vte])
-
+AC_CONFIG_AUX_DIR([.])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([src/vteapp.c])
 AC_CONFIG_HEADERS([config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,7 @@ AC_INIT([vte],
         [version_triplet],
         [http://bugzilla.gnome.org/enter_bug.cgi?product=vte],
         [vte])
+
 AC_CONFIG_AUX_DIR([.])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([src/vteapp.c])


### PR DESCRIPTION
Fixes #17

Fixes the issue by adding flags to explicitly set auxiliary directory as the current directory.