### PR TITLE
[backport] widget: Fix scrollbar drawing not to be delayed

### DIFF
--- a/src/vte.cc
+++ b/src/vte.cc
@@ -10871,10 +10871,6 @@ VteTerminalPrivate::invalidate_dirty_rects_and_process_updates()
         gtk_widget_queue_draw_region(m_widget, region);
 	cairo_region_destroy (region);
 
-	gdk_window_process_updates(gtk_widget_get_window(m_widget), FALSE);
-
-	_vte_debug_print (VTE_DEBUG_WORK, "-");
-
 	return true;
 }
 
@@ -10910,14 +10906,6 @@ update_repeat_timeout (gpointer data)
 		if (!again) {
                         remove_from_active_list(that);
 		}
-	}
-
-
-	if (g_active_terminals != nullptr) {
-		/* remove the idle source, and draw non-Terminals
-		 * (except for gdk/{directfb,quartz}!)
-		 */
-		gdk_window_process_all_updates ();
 	}
 
 	_vte_debug_print (VTE_DEBUG_WORK, "]");
@@ -10964,7 +10952,6 @@ static gboolean
 update_timeout (gpointer data)
 {
 	GList *l, *next;
-	gboolean redraw = FALSE;
 
         G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 	gdk_threads_enter();
@@ -10990,14 +10977,7 @@ update_timeout (gpointer data)
 
                 that->process(true);
 
-		redraw |= that->invalidate_dirty_rects_and_process_updates();
-	}
-
-	if (redraw) {
-		/* remove the idle source, and draw non-Terminals
-		 * (except for gdk/{directfb,quartz}!)
-		 */
-		gdk_window_process_all_updates ();
+                that->invalidate_dirty_rects_and_process_updates();
 	}
 
 	_vte_debug_print (VTE_DEBUG_WORK, "}");

--- a/src/vtegtk.cc
+++ b/src/vtegtk.cc
@@ -622,7 +622,6 @@ vte_terminal_class_init(VteTerminalClass *klass)
                                  "  !  _vte_invalidate_cells (dirty)\n"
                                  "  *  _vte_invalidate_all\n"
                                  "  )  end _vte_terminal_process_incoming\n"
-                                 "  -  gdk_window_process_updates\n"
                                  "  =  vte_terminal_paint\n"
                                  "  ]} end update_timeout\n"
                                  "  >  end process_timeout\n");


### PR DESCRIPTION
https://bugzilla.gnome.org/show_bug.cgi?id=771899

----------
This bug has been fixed months ago upstream, it is also in the 0.52 branch: https://github.com/thestinger/vte-ng/commit/809e79770b4dea34d64574710ce429a86855fdb2

As termite currently seems to build against 0.50 branch (please correct me if I'm wrong), 809e797 should probably be backported to vte-ng/0.50?

This would fix https://github.com/thestinger/termite/issues/559